### PR TITLE
Figure out in which directory to mount as '/repo'

### DIFF
--- a/docker-sqitch.sh
+++ b/docker-sqitch.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Figure out in which directory to mount as '/repo'
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+SQITCH_ROOT=${GIT_ROOT:-$(pwd)}
+SQITCH_REPO=${SQITCH_ROOT}${SQITCH_FOLDER:+/${SQITCH_FOLDER}}
+
 # Determine which Docker image to run.
 SQITCH_IMAGE=${SQITCH_IMAGE:=sqitch/sqitch:latest}
 
@@ -38,6 +43,6 @@ done
 
 # Run the container with the current and home directories mounted.
 docker run -it --rm --network host \
-    --mount "type=bind,src=$(pwd),dst=/repo" \
+    --mount "type=bind,src=${SQITCH_REPO:?},dst=/repo" \
     --mount "type=bind,src=$HOME,dst=/home" \
     "${passenv[@]}" "$SQITCH_IMAGE" "$@"


### PR DESCRIPTION
By default we mount current working directory (as before). When inside GIT
project we will mount it's top level directory. When environment variable
SQITCH_FOLDER (analogous to sqitch configuration 'core.top_dir') is set then we
use it's content as relative to GIT top level directory and mount it as '/repo'