### PR TITLE
Change home directory mountpoint to /root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY --from=sqitch-build /app .
 COPY --from=sqitch-build /etc /etc/
 
 # Set up environment, entrypoint, and default command.
-ENV LESS=-R HOME=/home LC_ALL=C.UTF-8 LANG=C.UTF-8 SQITCH_EDITOR=nano SQITCH_PAGER=less
+ENV LESS=-R HOME=/root LC_ALL=C.UTF-8 LANG=C.UTF-8 SQITCH_EDITOR=nano SQITCH_PAGER=less
 WORKDIR /repo
 ENTRYPOINT ["/bin/sqitch"]
 CMD ["help"]

--- a/docker-sqitch.sh
+++ b/docker-sqitch.sh
@@ -39,5 +39,5 @@ done
 # Run the container with the current and home directories mounted.
 docker run -it --rm --network host \
     --mount "type=bind,src=$(pwd),dst=/repo" \
-    --mount "type=bind,src=$HOME,dst=/home" \
+    --mount "type=bind,src=$HOME,dst=/root" \
     "${passenv[@]}" "$SQITCH_IMAGE" "$@"


### PR DESCRIPTION
The PostgreSQL libraries do not honor the `$HOME` environment variable when looking for configuration files like `.pgpass`.  This change amends the Dockerfile to mount the user's home directory in `/root` which conforms to the `/etc/passwd` entry for the root user.  This allows `sqitch` to successfully locate `.pgpass` for credentials when connecting to `db:pg:` targets.

This could alternatively be solved by overriding or changing `/etc/passwd` to point to `/home` for the root user, but this approach seemed the least invasive.

See Issue #2 for more information.