### PR TITLE
Fix passopt on Darwin with GNU Coreutils installed

### DIFF
--- a/docker-sqitch.sh
+++ b/docker-sqitch.sh
@@ -19,7 +19,7 @@ case "$(uname -s)" in
         passopt+=(-u $(id -u ${user}):$(id -g ${user}))
         ;;
     Darwin*)
-        passopt+=(-e "SQITCH_ORIG_FULLNAME=$(id -P $user | awk -F '[:]' '{print $8}')")
+        passopt+=(-e "SQITCH_ORIG_FULLNAME=$(/usr/bin/id -P $user | awk -F '[:]' '{print $8}')")
         ;;
     MINGW*|CYGWIN*)
         passopt+=(-e "SQITCH_ORIG_FULLNAME=$(net user $user)")


### PR DESCRIPTION
Like many others I have GNU Coreutils installed and setup as default utilities on my Mac. The GNU version of `id` command doesn't have `-P` option. I think the easiest way to prevent errors is to use full path to the OS X / BSD version.