### PR TITLE
Adding interactive working and passing commands for windows

### DIFF
--- a/docker-sqitch.bat
+++ b/docker-sqitch.bat
@@ -4,7 +4,11 @@ IF NOT DEFINED SQITCH_IMAGE (
     set SQITCH_IMAGE=sqitch/sqitch:latest
 )
 REM set SQITCH_IMAGE=sqitch/sqitch:latest
-
+SET interactive= 
+IF "%~1" == "" (
+    echo Running normal
+    SET interactive=-it --entrypoint /bin/bash
+)
 REM # Set up required pass-through variables.
 FOR /F "tokens=*" %%g IN ('whoami') do (SET user=%%g)
 set passopt= -e SQITCH_ORIG_SYSUSER="%username%"
@@ -43,7 +47,7 @@ echo %passopt%
 
 REM # Run the container with the current and home directories mounted.
 @echo on
-docker run -it --rm --network host ^
+docker run %interactive% --rm --network host ^
     --mount "type=bind,src=%cd%,dst=/repo" ^
     --mount "type=bind,src=%UserProfile%,dst=%homedst%" ^
     %passopt% %SQITCH_IMAGE% %*


### PR DESCRIPTION
Running sqitch command from Windows wasn't working.  I added the interactive entrypoint so that when you only type sqitch you are using it interactively.  But if you type additional parameters they are passed on to the container and run as intended.  Fully functional now for Windows users.