### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ curl -L https://git.io/JJKCn -o sqitch && chmod +x sqitch
 
 ```bat
 docker pull sqitch/sqitch
-curl -L https://git.io/JTAi6 -o sqitch
+curl -L https://git.io/JTAi6 -o sqitch.bat
 .\sqitch help
 ```
 


### PR DESCRIPTION
Fix file creation for Windows.

At least on Windows 11, `.\sqitch help` doesnt run without the script being a batch file. 

The second command does work without specifying the extension, I double checked