### PR TITLE
Fix env variable expansion in sqitch.bat

### DIFF
--- a/docker-sqitch.bat
+++ b/docker-sqitch.bat
@@ -28,7 +28,7 @@ for %%i in (
     SNOWSQL_ACCOUNT SNOWSQL_USER SNOWSQL_PWD SNOWSQL_HOST SNOWSQL_PORT SNOWSQL_DATABASE SNOWSQL_REGION SNOWSQL_WAREHOUSE SNOWSQL_PRIVATE_KEY_PASSPHRASE
 ) do if defined %%i (
     echo %%i is defined as !%%i!
-    SET passopt=!passopt! -e !%%i!
+    SET passopt=!passopt! -e %%i=!%%i!
 )
 
 REM # Determine the name of the container home directory.


### PR DESCRIPTION
See #64. 
env vars such as `SQITCH_USERNAME` were passed through as `-e <var value>` instead of `-e SQITCH_USERNAME=<var value>`