### PR TITLE
Upgrade the Snowflake and Exasol Libraries

### DIFF
--- a/exasol/Dockerfile
+++ b/exasol/Dockerfile
@@ -5,14 +5,14 @@ WORKDIR /work
 # Download and unpack EXAplus and the ODBC driver.
 # COPY *.tar.gz ./
 # https://downloads.exasol.com/clients-and-drivers
-ARG version=7.1.20
+ARG version=24.1.2
 ADD https://x-up.s3.amazonaws.com/7.x/$version/EXAplus-$version.tar.gz \
-    https://x-up.s3.amazonaws.com/7.x/$version/EXASOL_ODBC-$version.tar.gz \
+    https://x-up.s3.amazonaws.com/7.x/$version/Exasol_ODBC-$version-Linux_x86_64.tar.gz \
     ./
 
-RUN tar zxf EXASOL_ODBC-$version.tar.gz \
+RUN tar zxf Exasol_ODBC-$version-Linux_x86_64.tar.gz \
     && ls -l \
-    && mv EXASolution_ODBC-$version/lib/linux/x86_64/ odbc \
+    && mv Exasol_ODBC-$version-Linux_x86_64/lib odbc \
     && tar zxf EXAplus-$version.tar.gz \
     && mv EXAplus-$version/ exaplus \
     && rm -rf exaplus/doc

--- a/exasol/README.md
+++ b/exasol/README.md
@@ -1,6 +1,9 @@
 Sqitch Exasol Docker Image
 ==========================
 
-Build an image named `sqitch-exasol` with this command:
+Build an image named `sqitch-exasol` with this command from the root
+directory:
 
-    docker build -t sqitch-exasol .
+``` sh
+env env DIR=exasol ARCHS=amd64 ./build
+```

--- a/exasol/odbcinst.ini
+++ b/exasol/odbcinst.ini
@@ -1,3 +1,3 @@
 [Exasol]
 Description = ODBC for Exasol
-Driver      = /opt/exasol/odbc/lib/libexaodbc-uo2214lv2.so
+Driver      = /opt/exasol/odbc/lib/libexaodbc.so

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -1,18 +1,21 @@
 Sqitch Oracle Docker Image
 ==========================
 
-1.  Build an image named `sqitch-oracle` with this command
+1.  Build an x86 image named `sqitch-oracle` with the latest version of
+    [Instant Client] by running this command from the root directory:
 
-        docker build -t sqitch-oracle .
+    ``` sh
+    env env DIR=oracle ARCHS=amd64 ./build
+    ```
 
-    If you want to control the version of [Instant Client], pass the
-    `INSTANTCLIENT_VERSION` AND `INSTANTCLIENT_VDIR` (the version with dots
-    removed) arguments:
-
-        docker build -t sqitch-oracle \
-               --build-arg INSTANTCLIENT_VERSION=21.3.0.0.0 \
-               --build-arg INSTANTCLIENT_VDIR=213000 \
-               .
+    > Support for arm64 is included, but DBD::Oracle fails to build with this
+    > error:
+    >
+    >     39.41 /usr/bin/ld: cannot find -lclntshcore: No such file or directory
+    >
+    > The file seems to be missing from the arm64 Instant Client download.
+    > Once it's fixed, remove `ARCHS=amd64` from the above command to build
+    > both x86 and arm64 images.
 
 2.  Set up a [`tnsnames.ora` file] in your home directory. For example,
     `~./sqlplus/tnsnames.ora`.

--- a/snowflake/Dockerfile
+++ b/snowflake/Dockerfile
@@ -2,14 +2,6 @@ FROM debian:bookworm-slim AS snow-build
 
 WORKDIR /work
 
-# Download the ODBC driver and SnowSQL.
-# https://docs.snowflake.com/en/user-guide/snowsql-install-config
-# https://docs.snowflake.com/en/release-notes/client-change-log-snowsql
-# https://sfc-repo.snowflakecomputing.com/index.html
-ENV ODBC_VERSION=3.1.0
-# No ARM-specific SnowSQL yet.
-# https://community.snowflake.com/s/question/0D5Do00000ltxpVKAQ/snowsql-linuxarm64-support
-ADD https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.2/linux_x86_64/snowsql-1.2.28-linux_x86_64.bash snowsql.bash
 COPY conf ./
 
 # Tell SnowSQL where to store its versions and config. Need to keep it inside
@@ -20,13 +12,22 @@ ENV WORKSPACE /var/snowsql
 # Set locale for Python triggers.
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 
+# CONFIGURE the ODBC driver and SnowSQL versions to download.
+# https://docs.snowflake.com/en/user-guide/snowsql-install-config
+# https://docs.snowflake.com/en/release-notes/client-change-log-snowsql
+# https://sfc-repo.snowflakecomputing.com/index.html
+ARG ODBC_VERSION=3.4.0
+ARG SNOWSQL_VERSION=1.3.2
+
 # Install prereqs.
 ARG sf_account
 RUN apt-get -qq update \
     && apt-get -qq --no-install-recommends install odbcinst curl ca-certificates \
-    # Configure ODBC. https://docs.snowflake.net/manuals/user-guide/odbc-linux.html
-    && case "$(arch)" in aarch64) export SNOWPLAT=aarch64 DIRARCH=aarch64 ;; x86_64) export SNOWPLAT=x8664 ;; esac \
-    && curl https://sfc-repo.snowflakecomputing.com/odbc/linux${DIRARCH}/${ODBC_VERSION}/snowflake_linux_${SNOWPLAT}_odbc-${ODBC_VERSION}.tgz -o snowflake_odbc.tgz \
+    # Set variables for downloading the proper ODBC & SnowSQL files.
+    && case "$(arch)" in aarch64) export SNOWPLAT=aarch64 ODBCPLAT=aarch64 DIRARCH=aarch64 ;; x86_64) export ODBCPLAT=x8664 SNOWPLAT=x86_64 ;; esac \
+    # Configure ODBC.
+    # https://docs.snowflake.net/manuals/user-guide/odbc-linux.html
+    && curl https://sfc-repo.snowflakecomputing.com/odbc/linux${DIRARCH}/${ODBC_VERSION}/snowflake_linux_${ODBCPLAT}_odbc-${ODBC_VERSION}.tgz -o snowflake_odbc.tgz \
     && gunzip -f *.tgz && tar vxf *.tar \
     && mkdir odbc \
     && mv snowflake_odbc/lib snowflake_odbc/ErrorMessages odbc/ \
@@ -37,6 +38,7 @@ RUN apt-get -qq update \
     && cat odbcinst.ini >> /etc/odbcinst.ini \
     # Unpack and upgrade snowsql, then overwrite its config file.
     # && SNOWSQL_DEST=. SNOWSQL_LOGIN_SHELL=/dev/null bash snowsql.bash \
+    && curl https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.3/linux_${SNOWPLAT}/snowsql-1.3.2-linux_${SNOWPLAT}.bash -o snowsql.bash \
     && sed -e '1,/^exit$/d' snowsql.bash | tar zxf - \
     && ./snowsql -Uv \
     && echo "[connections]\naccountname = $sf_account\n\n[options]\nnoup = true" > /var/snowsql/.snowsql/config


### PR DESCRIPTION
Also support arm64 in the Snowflake image. Tweak the READMEs a bit to use the `build` script. Also update the Oracle README to note the reason arm64 isn't (yet) supported.

Resolves #61.