### PR TITLE
Fix Snowflake ODBC configuration

### DIFF
--- a/build
+++ b/build
@@ -34,7 +34,7 @@ if [ "$GITHUB_REF_TYPE" == "tag" ]; then
     fi
 fi
 
-# Build and export imaages to Docker for all supported architectures.
+# Build and export images to Docker for all supported architectures.
 for arch in $ARCHS; do
     printf "Building for linux/%s\n" "${arch}"
     docker buildx build --platform="linux/${arch}" --pull --load --progress=plain \

--- a/docker-sqitch.sh
+++ b/docker-sqitch.sh
@@ -16,7 +16,7 @@ passopt=(
 case "$(uname -s)" in
     Linux*)
         passopt+=(-e "SQITCH_ORIG_FULLNAME=$(getent passwd $user | cut -d: -f5 | cut -d, -f1)")
-        passopt+=(-u $(id -u ${user}):$(id -g ${user}))
+        passopt+=(-u "$(id -u "${user}"):$(id -g "${user}")")
         ;;
     Darwin*)
         passopt+=(-e "SQITCH_ORIG_FULLNAME=$(/usr/bin/id -P $user | awk -F '[:]' '{print $8}')")
@@ -42,13 +42,13 @@ for var in \
     SNOWSQL_ACCOUNT SNOWSQL_USER SNOWSQL_PWD SNOWSQL_HOST SNOWSQL_PORT SNOWSQL_DATABASE SNOWSQL_REGION SNOWSQL_WAREHOUSE SNOWSQL_PRIVATE_KEY_PASSPHRASE SNOWSQL_ROLE
 do
     if [ -n "${!var}" ]; then
-       passopt+=(-e $var)
+       passopt+=(-e "$var")
     fi
 done
 
 # Determine the name of the container home directory.
 homedst=/home
-if [ $(id -u ${user}) -eq 0 ]; then
+if [ "$(id -u "${user}")" -eq 0 ]; then
     homedst=/root
 fi
 # Set HOME, since the user ID likely won't be the same as for the sqitch user.

--- a/snowflake/Dockerfile
+++ b/snowflake/Dockerfile
@@ -17,7 +17,7 @@ ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 # https://docs.snowflake.com/en/release-notes/clients-drivers/snowsql
 # https://sfc-repo.snowflakecomputing.com/index.html
 ARG ODBC_VERSION=3.5.0
-ARG SNOWSQL_VERSION=1.3.2
+ARG SNOWSQL_VERSION=1.3.3
 
 # Install prereqs.
 ARG sf_account
@@ -45,7 +45,7 @@ RUN apt-get -qq update \
 
 FROM sqitch/sqitch:latest
 
-# Install runtime dependencies, remove unnecesary files, and create log dir.
+# Install runtime dependencies, remove unnecessary files, and create log dir.
 USER root
 RUN apt-get -qq update \
     && apt-get -qq --no-install-recommends install unixodbc \

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -10,7 +10,8 @@ Sqitch) with this command from the root directory of this project, replacing
 
 The build will download the [SnowSQL installer] and [ODBC driver] from public
 repositories; if there are errors, check that the version number are correct
-in the [client changes].
+in the [client changes]. The image will contain an `odbc.ini` DSN named for
+`$ACCOUNT`.
 
 If the resulting image will be pushed to a private Docker registry, set the
 `$REGISTRY` environment variable:
@@ -35,6 +36,10 @@ Or from a private repository:
 ``` sh
 env SQITCH_IMAGE=registry.example.com/sqitch:snowflake ./sqitch
 ```
+
+To add additional DSNs or configurations, edit `~/.odbc.ini` on the Docker
+host server, which `docker-sqitch.ini` mounts as the home directory inside the
+container.
 
   [SnowSQL installer]: https://docs.snowflake.net/manuals/user-guide/snowsql-install-config.html
   [ODBC driver]: https://docs.snowflake.net/manuals/user-guide/odbc-download.html

--- a/snowflake/conf/odbc.ini
+++ b/snowflake/conf/odbc.ini
@@ -1,15 +1,12 @@
 [ODBC Data Sources]
-SF_ACCOUNT = Snowflake DSN for SF_ACCOUNT
+SF_ACCOUNT = Snowflake
 
 [SF_ACCOUNT]
-Description=SnowflakeDB
-Driver=/opt/snowflake/lib/libSnowflake.so
-Locale=en-US
-SERVER=SF_ACCOUNT.snowflakecomputing.com
-PORT=443
-SSL=on
+Driver=/usr/lib/snowflake/odbc/lib/libSnowflake.so
 ACCOUNT=SF_ACCOUNT
 
-# Sadly does not work: https://github.com/sqitchers/docker-sqitch/pull/16/.
-[Default]
-Driver=/opt/snowflake/lib/libSnowflake.so
+# Kay Pair Auth config. https://docs.snowflake.com/en/developer-guide/odbc/odbc-parameters#using-key-pair-authentication
+# AUTHENTICATOR     = SNOWFLAKE_JWT
+# UID               = <username>
+# PRIV_KEY_FILE     = <path>/rsa_key.p8
+# PRIV_KEY_FILE_PWD = <password>

--- a/snowflake/conf/odbcinst.ini
+++ b/snowflake/conf/odbcinst.ini
@@ -6,4 +6,4 @@ Snowflake=Installed
 Driver=Snowflake
 
 [Snowflake]
-Driver=/opt/snowflake/lib/libSnowflake.so
+Driver=/usr/lib/snowflake/odbc/lib/libSnowflake.so


### PR DESCRIPTION
The `SF_ACCOUNT` item under `ODBC Data Sources` was incorrectly pointing at a description instead of driver named in `odbcinst.ini`. As a result none of its configs ever did anything. Fix it to properly point to `Snowflake`, the default driver named in `odbcinst.ini` and keep only the config necessary for it to operate, `Driver`. But also add a comment listing Snowflake key pair configs.

Speaking of the `odbcinst.ini` entry, fix its `Driver` config to point to the actual location of the `libSnowflake.so` file. With these changes, the resulting Docker image properly works with Snowflake.

While at it, fix shell linting issues in `docker-sqitch.sh` and add some notes about custom configuration to the Snowflake README.