### PR TITLE
Upgrade base image from Debian Bookworm to Trixie

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,7 +48,7 @@ jobs:
             org.opencontainers.image.source=${{ env.SOURCE }}
             org.opencontainers.image.version=v${{ env.VERSION }}
             org.opencontainers.image.licenses=${{ env.LICENSE }}
-            org.opencontainers.image.ref.name=docker.io/debian/bookworm-slim
+            org.opencontainers.image.ref.name=docker.io/debian/trixie-slim
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS sqitch-build
+FROM debian:trixie-slim AS sqitch-build
 
 # Install system dependencies.
 WORKDIR /work
@@ -31,12 +31,12 @@ RUN perl Build.PL --quiet --install_base /app --etcdir /etc/sqitch \
 
 ################################################################################
 # Copy to the final image without all the build stuff.
-FROM debian:bookworm-slim AS sqitch
+FROM debian:trixie-slim AS sqitch
 
 # Install runtime system dependencies and remove unnecessary files.
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get -qq update \
-    && apt-get -qq --no-install-recommends install less libperl5.36 perl-doc nano ca-certificates \
+    && apt-get -qq --no-install-recommends install less libperl5.40 perl-doc nano ca-certificates \
        sqlite3 \
        firebird3.0-utils libfbclient2 \
        libpq5 postgresql-client \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Description
 -----------
 
 This project is the source for creating the official [Sqitch Project] Docker
-Image. It's built on [Debian bookworm-slim] in an effort to keep the image as
+Image. It's built on [Debian trixie-slim] in an effort to keep the image as
 small as possible while supporting all known engines. It includes support for
 managing [PostgreSQL], [CockroachDB], [YugabyteDB], [SQLite], [MariaDB]
 ([MySQL]), and [Firebird] databases. Images whose tags include `clickhouse`
@@ -88,7 +88,7 @@ Notes
     one based on this image and add whatever editors you like.
 
   [Sqitch Project]: https://sqitch.org
-  [Debian bookworm-slim]: https://hub.docker.com/_/debian/tags?name=bookworm-slim
+  [Debian trixie-slim]: https://hub.docker.com/_/debian/tags?name=trixie-slim
   [PostgreSQL]: https://postgresql.org
   [YugabyteDB]: https://www.yugabyte.com/yugabytedb/
   [CockroachDB]: https://www.cockroachlabs.com/product/

--- a/clickhouse/Dockerfile
+++ b/clickhouse/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION
 # Alas, the ClickHouse ODBC drivers are not yet available for ARM.
 # https://github.com/ClickHouse/clickhouse-odbc/issues/524
-FROM --platform=${BUILDPLATFORM} debian:bookworm-slim AS ch-build
+FROM --platform=${BUILDPLATFORM} debian:trixie-slim AS ch-build
 
 WORKDIR /work
 

--- a/exasol/Dockerfile
+++ b/exasol/Dockerfile
@@ -1,5 +1,5 @@
 # The Exasol ODBC driver is not available for ARM64.
-FROM --platform=${BUILDPLATFORM} debian:bookworm-slim AS exa-build
+FROM --platform=${BUILDPLATFORM} debian:trixie-slim AS exa-build
 
 WORKDIR /work
 

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS ora-build
+FROM debian:trixie-slim AS ora-build
 
 WORKDIR /work
 

--- a/snowflake/Dockerfile
+++ b/snowflake/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS snow-build
+FROM debian:trixie-slim AS snow-build
 
 WORKDIR /work
 


### PR DESCRIPTION
## Summary

This PR upgrades the base Docker image from Debian Bookworm to Debian Trixie, the new stable release of Debian (Debian 13).

### Changes
- Update all Dockerfiles to use `debian:trixie-slim`
- Update `libperl5.36` to `libperl5.40` (Perl 5.40 in Trixie)
- Update CI/CD workflow image reference metadata
- Update README documentation links

## Testing Performed

- **Build**: Successfully built the main sqitch image
- **Smoke tests**: Verified `sqitch --version` and `sqitch help` work correctly
- **Perl modules**: Verified `App::Sqitch`, `DBI`, `DBD::Pg`, `DBD::SQLite` load correctly
- **SQLite**: Tested the full workflow (init, add, deploy, status, verify, revert)
- **PostgreSQL**: Tested the full workflow against a PostgreSQL 16 container

## Help Requested

I don't have enough context on the other database engines (Firebird, ClickHouse, Oracle, Snowflake, Exasol) to test them properly. @theory, would you be able to help verify those work correctly with Trixie?

## Known Issue: MariaDB/MySQL SSL

During testing, I discovered that MariaDB client 11.8.3 (included in Trixie) has **SSL enabled by default**, which causes connection failures to MySQL servers without proper SSL certificates:

```
ERROR 2026 (HY000): TLS/SSL error: self-signed certificate in certificate chain
```

This is a change in the MariaDB client package behavior, not specific to Trixie. If Bookworm's MariaDB client gets updated to this version, it would exhibit the same behavior. Users connecting to MySQL/MariaDB servers may need to:
- Configure proper SSL certificates on their database servers, or
- Use `--ssl-mode=DISABLED` in their connection options

MySQL is not my strong suit, so I'd appreciate some extra eyes on this testing. I wanted to document this for awareness.