### PR TITLE
Upgrade client libraries, improve var handling

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,10 +1,10 @@
 NAME=sqitch
 TITLE=Sqitch
-VERSION=1.6.1
+VERSION=v1.6.1
 IMAGE=sqitch/sqitch
-DESCRIPTION=Sensible database change management
-VENDOR=The Sqitch Community
-AUTHORS=Sqitch Hackers <sqitch-hackers@googlegroups.com>
+DESCRIPTION="Sensible database change management"
+VENDOR="The Sqitch Community"
+AUTHORS="Sqitch Hackers <sqitch-hackers@googlegroups.com>"
 URL=https://hub.docker.com/r/sqitch/sqitch/
 DOCS=https://github.com/sqitchers/docker-sqitch#readme
 SOURCE=https://github.com/sqitchers/docker-sqitch

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,7 +48,7 @@ jobs:
             org.opencontainers.image.source=${{ env.SOURCE }}
             org.opencontainers.image.version=v${{ env.VERSION }}
             org.opencontainers.image.licenses=${{ env.LICENSE }}
-            org.opencontainers.image.ref.name=docker.io/debian/bookworm-slim
+            org.opencontainers.image.ref.name=docker.io/debian/trixie-slim
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Environment
-        run: cat .envrc >> "$GITHUB_ENV"
+        run: cat .envrc | tr -d '"' >> "$GITHUB_ENV"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -46,7 +46,7 @@ jobs:
             org.opencontainers.image.url=${{ env.URL }}
             org.opencontainers.image.documentation=${{ env.DOCS }}
             org.opencontainers.image.source=${{ env.SOURCE }}
-            org.opencontainers.image.version=v${{ env.VERSION }}
+            org.opencontainers.image.version=${{ env.VERSION }}
             org.opencontainers.image.licenses=${{ env.LICENSE }}
             org.opencontainers.image.ref.name=docker.io/debian/trixie-slim
 
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Environment
-        run: cat .envrc >> "$GITHUB_ENV"
+        run: cat .envrc | tr -d '"' >> "$GITHUB_ENV"
       # Restore when ClickHouse ODBC supports arm64.
       # - name: Set up QEMU
       #   uses: docker/setup-qemu-action@v3
@@ -127,7 +127,7 @@ jobs:
             org.opencontainers.image.url=${{ env.URL }}
             org.opencontainers.image.documentation=${{ env.DOCS }}
             org.opencontainers.image.source=${{ env.SOURCE }}
-            org.opencontainers.image.version=v${{ env.VERSION }}
+            org.opencontainers.image.version=${{ env.VERSION }}
             org.opencontainers.image.licenses=${{ env.LICENSE }}
             org.opencontainers.image.ref.name=docker.io/sqitch/sqitch:${{ env.VERSION }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS sqitch-build
+FROM debian:trixie-slim AS sqitch-build
 
 # Install system dependencies.
 WORKDIR /work
@@ -31,12 +31,12 @@ RUN perl Build.PL --quiet --install_base /app --etcdir /etc/sqitch \
 
 ################################################################################
 # Copy to the final image without all the build stuff.
-FROM debian:bookworm-slim AS sqitch
+FROM debian:trixie-slim AS sqitch
 
 # Install runtime system dependencies and remove unnecessary files.
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get -qq update \
-    && apt-get -qq --no-install-recommends install less libperl5.36 perl-doc nano ca-certificates \
+    && apt-get -qq --no-install-recommends install less libperl5.40 perl-doc nano ca-certificates \
        sqlite3 \
        firebird3.0-utils libfbclient2 \
        libpq5 postgresql-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get -qq update \
     && apt-get -qq install build-essential perl curl \
        unixodbc-dev firebird-dev sqlite3 libpq-dev libmariadb-dev \
-    && curl -LO https://github.com/sqitchers/sqitch/releases/download/v$VERSION/App-Sqitch-v$VERSION.tar.gz \
+    && curl -LfO https://github.com/sqitchers/sqitch/releases/download/$VERSION/App-Sqitch-$VERSION.tar.gz \
     && mkdir src \
-    && tar -zxf App-Sqitch-v$VERSION.tar.gz --strip-components 1 -C src
+    && tar -zxf App-Sqitch-$VERSION.tar.gz --strip-components 1 -C src
 
 # Install cpan and build dependencies.
 ENV PERL5LIB=/work/local/lib/perl5
-RUN curl -sL --compressed https://git.io/cpm > cpm && chmod +x cpm \
+RUN curl -sfL --compressed https://git.io/cpm > cpm && chmod +x cpm \
     && ./cpm install -L local --verbose --no-test --show-build-log-on-failure ExtUtils::MakeMaker List::MoreUtils::XS \
     && ./cpm install -L local --verbose --no-test --show-build-log-on-failure --with-recommends \
         --with-configure --cpanfile src/dist/cpanfile

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Description
 -----------
 
 This project is the source for creating the official [Sqitch Project] Docker
-Image. It's built on [Debian bookworm-slim] in an effort to keep the image as
+Image. It's built on [Debian trixie-slim] in an effort to keep the image as
 small as possible while supporting all known engines. It includes support for
 managing [PostgreSQL], [CockroachDB], [YugabyteDB], [SQLite], [MariaDB]
 ([MySQL]), and [Firebird] databases. Images whose tags include `clickhouse`
@@ -88,7 +88,7 @@ Notes
     one based on this image and add whatever editors you like.
 
   [Sqitch Project]: https://sqitch.org
-  [Debian bookworm-slim]: https://hub.docker.com/_/debian/tags?name=bookworm-slim
+  [Debian trixie-slim]: https://hub.docker.com/_/debian/tags?name=trixie-slim
   [PostgreSQL]: https://postgresql.org
   [YugabyteDB]: https://www.yugabyte.com/yugabytedb/
   [CockroachDB]: https://www.cockroachlabs.com/product/

--- a/build
+++ b/build
@@ -23,7 +23,7 @@ fi
 # Always include "latest" and the version.
 tagopt=(
     --tag "${REGISTRY}/${NAME}:${TAG}"
-    --tag "${REGISTRY}/${NAME}:v${VERSION}${PKG}"
+    --tag "${REGISTRY}/${NAME}:${VERSION}${PKG}"
 )
 
 # Include the git tag if differnt from the version.
@@ -43,11 +43,11 @@ for arch in $ARCHS; do
     --label org.opencontainers.image.url="${URL}" \
     --label org.opencontainers.image.documentation="${DOCS}" \
     --label org.opencontainers.image.source="${SOURCE}" \
-    --label org.opencontainers.image.version="v${VERSION}" \
+    --label org.opencontainers.image.version="${VERSION}" \
     --label org.opencontainers.image.revision="$(git rev-parse --abbrev-ref HEAD)" \
     --label org.opencontainers.image.vendor="${VENDOR}" \
     --label org.opencontainers.image.licenses="${LICENSE}" \
-    --label org.opencontainers.image.ref.name="${NAME}${PKG}-v${VERSION}" \
+    --label org.opencontainers.image.ref.name="${NAME}${PKG}-${VERSION}" \
     --label org.opencontainers.image.title="${TITLE}" \
     --label org.opencontainers.image.description="${DESCRIPTION}" \
     "${tagopt[@]}" \

--- a/clickhouse/Dockerfile
+++ b/clickhouse/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION
 # Alas, the ClickHouse ODBC drivers are not yet available for ARM.
 # https://github.com/ClickHouse/clickhouse-odbc/issues/524
-FROM --platform=${BUILDPLATFORM} debian:bookworm-slim AS ch-build
+FROM --platform=${BUILDPLATFORM} debian:trixie-slim AS ch-build
 
 WORKDIR /work
 

--- a/clickhouse/Dockerfile
+++ b/clickhouse/Dockerfile
@@ -15,9 +15,9 @@ ARG TARGETARCH
 
 RUN apt-get -qq update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -qq curl unzip \
-    && LATEST_VERSION=$(curl -s "${TSV_URL}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -V -r | head -n 1) \
-    && curl -sSL "https://packages.clickhouse.com/tgz/stable/clickhouse-common-static-$LATEST_VERSION-${TARGETARCH}.tgz" | tar zxf - --strip-components 1 \
-    && curl -sSLo odbc.zip "https://github.com/ClickHouse/clickhouse-odbc/releases/download/${ODBC_VERSION}.${ODBC_DATE}/clickhouse-odbc-linux-Clang-UnixODBC-Release.zip" \
+    && LATEST_VERSION=$(curl -sf "${TSV_URL}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -V -r | head -n 1) \
+    && curl -sSLf "https://packages.clickhouse.com/tgz/stable/clickhouse-common-static-$LATEST_VERSION-${TARGETARCH}.tgz" | tar zxf - --strip-components 1 \
+    && curl -sSLfo odbc.zip "https://github.com/ClickHouse/clickhouse-odbc/releases/download/${ODBC_VERSION}.${ODBC_DATE}/clickhouse-odbc-linux-Clang-UnixODBC-Release.zip" \
     && mkdir odbc \
     && unzip -p odbc.zip "clickhouse-odbc-${ODBC_VERSION}-Linux.tar.gz" | tar -xzf - --strip-components 1 -C odbc
 

--- a/exasol/Dockerfile
+++ b/exasol/Dockerfile
@@ -1,5 +1,5 @@
 # The Exasol ODBC driver is not available for ARM64.
-FROM --platform=${BUILDPLATFORM} debian:bookworm-slim AS exa-build
+FROM --platform=${BUILDPLATFORM} debian:trixie-slim AS exa-build
 
 WORKDIR /work
 

--- a/exasol/Dockerfile
+++ b/exasol/Dockerfile
@@ -1,3 +1,4 @@
+ARG VERSION
 # The Exasol ODBC driver is not available for ARM64.
 FROM --platform=${BUILDPLATFORM} debian:trixie-slim AS exa-build
 
@@ -6,19 +7,18 @@ WORKDIR /work
 # Download and unpack EXAplus and the ODBC driver.
 # COPY *.tar.gz ./
 # https://downloads.exasol.com/clients-and-drivers
-ARG version=25.2.4
-ADD https://x-up.s3.amazonaws.com/7.x/$version/EXAplus-$version.tar.gz \
-    https://x-up.s3.amazonaws.com/7.x/$version/Exasol_ODBC-$version-Linux_x86_64.tar.gz \
+ARG exa_version=25.2.5
+ADD https://x-up.s3.amazonaws.com/7.x/$exa_version/EXAplus-$exa_version.tar.gz \
+    https://x-up.s3.amazonaws.com/7.x/$exa_version/Exasol_ODBC-$exa_version-Linux_x86_64.tar.gz \
     ./
 
-RUN tar zxf Exasol_ODBC-$version-Linux_x86_64.tar.gz \
-    && ls -l \
-    && mv Exasol_ODBC-$version-Linux_x86_64/lib odbc \
-    && tar zxf EXAplus-$version.tar.gz \
-    && mv EXAplus-$version/ exaplus \
+RUN tar zxf Exasol_ODBC-$exa_version-Linux_x86_64.tar.gz \
+    && mv Exasol_ODBC-$exa_version-Linux_x86_64/lib odbc \
+    && tar zxf EXAplus-$exa_version.tar.gz \
+    && mv EXAplus-$exa_version/ exaplus \
     && rm -rf exaplus/doc
 
-FROM --platform=${BUILDPLATFORM} sqitch/sqitch:latest
+FROM --platform=${BUILDPLATFORM} sqitch/sqitch:${VERSION:-latest}
 
 # Install runtime dependencies, remove unnecessary files, and create symlink.
 USER root

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -1,3 +1,4 @@
+ARG VERSION
 FROM debian:trixie-slim AS ora-build
 
 WORKDIR /work
@@ -16,9 +17,9 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && apt-get -qq update \
     && apt-get -qq install build-essential libarchive-tools curl libaio-dev \
     && case "$(arch)" in aarch64) export ORAPLAT=-arm64 ;; x86_64) export ORAPLAT=x64 ;; esac \
-    && curl "${BASEURI}-basic-linux${ORAPLAT}.zip" -o instantclient-basic.zip \
-    && curl "${BASEURI}-sqlplus-linux${ORAPLAT}.zip" -o instantclient-sqlplus.zip \
-    && curl "${BASEURI}-sdk-linux${ORAPLAT}.zip" -o instantclient-sdk.zip \
+    && curl -f "${BASEURI}-basic-linux${ORAPLAT}.zip" -o instantclient-basic.zip \
+    && curl -f "${BASEURI}-sqlplus-linux${ORAPLAT}.zip" -o instantclient-sqlplus.zip \
+    && curl -f "${BASEURI}-sdk-linux${ORAPLAT}.zip" -o instantclient-sdk.zip \
     && mkdir instantclient \
     && bsdtar -C instantclient --strip-components 1 -zxf instantclient-basic.zip \
     && bsdtar -C instantclient --strip-components 1 -zxf instantclient-sqlplus.zip \
@@ -26,7 +27,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && cp -rf instantclient instantclient.install \
     && bsdtar -C instantclient --strip-components 1 -zxf instantclient-sdk.zip \
     # Install DBI in its own directory, then install DBD::Oracle.
-    && curl https://cpanmin.us > cpanm && chmod +x cpanm \
+    && curl -f https://cpanmin.us > cpanm && chmod +x cpanm \
     && ./cpanm install -l tmp --quiet --notest DBI \
     && ./cpanm install -l local --quiet --notest --no-man-pages DBD::Oracle \
     # Remove unneeded files.
@@ -37,7 +38,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     && find local -type d -empty -delete \
     && rm -rf instantclient.install/*.jar instantclient.install/*README instantclient.install/nework
 
-FROM sqitch/sqitch:latest
+FROM sqitch/sqitch:${VERSION:-latest}
 
 # Install instantclient basic and SQL*Plus and copy DBD::Oracle.
 USER root

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS ora-build
+FROM debian:trixie-slim AS ora-build
 
 WORKDIR /work
 

--- a/snowflake/Dockerfile
+++ b/snowflake/Dockerfile
@@ -1,3 +1,4 @@
+ARG VERSION
 FROM debian:trixie-slim AS snow-build
 
 WORKDIR /work
@@ -16,7 +17,7 @@ ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 # https://docs.snowflake.com/en/user-guide/snowsql-install-config
 # https://docs.snowflake.com/en/release-notes/clients-drivers/snowsql
 # https://sfc-repo.snowflakecomputing.com/index.html
-ARG ODBC_VERSION=3.11.0
+ARG ODBC_VERSION=3.14.0
 ARG SNOWSQL_VERSION=1.4.5
 
 # Install prereqs.
@@ -27,7 +28,7 @@ RUN apt-get -qq update \
     && case "$(arch)" in aarch64) export SNOWPLAT=aarch64 ODBCPLAT=aarch64 DIRARCH=aarch64 ;; x86_64) export ODBCPLAT=x8664 SNOWPLAT=x86_64 ;; esac \
     # Configure ODBC.
     # https://docs.snowflake.net/manuals/user-guide/odbc-linux.html
-    && curl https://sfc-repo.snowflakecomputing.com/odbc/linux${DIRARCH}/${ODBC_VERSION}/snowflake_linux_${ODBCPLAT}_odbc-${ODBC_VERSION}.tgz -o snowflake_odbc.tgz \
+    && curl -f https://sfc-repo.snowflakecomputing.com/odbc/linux${DIRARCH}/${ODBC_VERSION}/snowflake_linux_${ODBCPLAT}_odbc-${ODBC_VERSION}.tgz -o snowflake_odbc.tgz \
     && gunzip -f *.tgz && tar vxf *.tar \
     && mkdir odbc \
     && mv snowflake_odbc/lib snowflake_odbc/ErrorMessages odbc/ \
@@ -38,12 +39,12 @@ RUN apt-get -qq update \
     && cat odbcinst.ini >> /etc/odbcinst.ini \
     # Unpack and upgrade snowsql, then overwrite its config file.
     # && SNOWSQL_DEST=. SNOWSQL_LOGIN_SHELL=/dev/null bash snowsql.bash \
-    && curl https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.3/linux_${SNOWPLAT}/snowsql-1.3.2-linux_${SNOWPLAT}.bash -o snowsql.bash \
+    && curl -f https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/${SNOWSQL_VERSION%.*}/linux_${SNOWPLAT}/snowsql-${SNOWSQL_VERSION}-linux_${SNOWPLAT}.bash -o snowsql.bash \
     && sed -e '1,/^exit$/d' snowsql.bash | tar zxf - \
     && ./snowsql -Uv \
     && echo "[connections]\naccountname = $sf_account\n\n[options]\nnoup = true" > /var/snowsql/.snowsql/config
 
-FROM sqitch/sqitch:latest
+FROM sqitch/sqitch:${VERSION:-latest}
 
 # Install runtime dependencies, remove unnecessary files, and create log dir.
 USER root

--- a/snowflake/Dockerfile
+++ b/snowflake/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS snow-build
+FROM debian:trixie-slim AS snow-build
 
 WORKDIR /work
 


### PR DESCRIPTION
Restore quotation marks to `.envrc` values that need them, then teach `cicd.yml` to strip them out for use in `$GITHUB_ENV`.

Revamp handling of the `$VERSION` environment variable by not prepending it with `v`; instead put the `v` in `.envrc`. Then use a fallback to `latest` when it's not set.

Add the `-f` flag to `curl` calls, so that 404 responses trigger an error.

Update the Exasol clients to v25.2.5.

Fix the Snowflake `Dockerfile` to properly install the specified version of SnowSQL (1.4.5), rather than the hard-coded 1.3.2.