### PR TITLE
Fix bat env var quoting for values with spaces

### DIFF
--- a/docker-sqitch.bat
+++ b/docker-sqitch.bat
@@ -29,7 +29,7 @@ for %%i in (
     CLICKHOUSE_HOST CLICKHOUSE_USER CLICKHOUSE_PASSWORD
 ) do if defined %%i (
     echo %%i is defined as !%%i!
-    SET passopt=!passopt! -e %%i=!%%i!
+    SET passopt=!passopt! -e "%%i"
 )
 
 REM # Determine the name of the container home directory.


### PR DESCRIPTION
The passopt loop builds -e KEY=VALUE arguments for docker run by expanding the variable inline: -e %%i=!%%i!

When a value contains spaces (e.g. SQITCH_FULLNAME=Foo Bar), this produces an unquoted argument that Docker misparses:
  -e SQITCH_FULLNAME=Foo Bar
Docker treats 'Bar' as a positional argument (image name), causing: invalid reference format: repository name (library/Bar) must be lowercase

Use Docker's inherit syntax (-e "VARNAME") instead of explicitly constructing -e KEY=VALUE. This tells Docker to read the value from the host environment, which:
- Fixes spaces in values (the original bug)
- Avoids all cmd.exe quoting edge cases (quotes, !, &, etc.)
- Matches docker-sqitch.sh which already uses -e "$var" (inherit from host) on line 46